### PR TITLE
Fix typo and make modal text not copyable

### DIFF
--- a/frontend/src/components/MainGame.css
+++ b/frontend/src/components/MainGame.css
@@ -329,3 +329,10 @@
     text-align: center;
     font-size: 1.25rem;
 }
+
+.modal-main-text {
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+}

--- a/frontend/src/components/MainGame.js
+++ b/frontend/src/components/MainGame.js
@@ -186,7 +186,7 @@ function MainGame({
           <EuiModalBody>
             <EuiText className="modal-main-text">
               <p>
-                Fill 5 shopping bags with items from our grocery inventory in Elasicsearch.
+                Fill 5 shopping bags with items from our grocery inventory in Elasticsearch.
               </p>
               <p>The twist:</p>
               <p>Each bag can contain an unlimited number of any unique items, but your total


### PR DESCRIPTION
- Fixed "Elasicsearch" typo
- Text in the rules modal is not copyable so user can not copy paste the instructions to the prompt